### PR TITLE
docs: create api requirement template

### DIFF
--- a/.github/ISSUE_TEMPLATE/api_description.md
+++ b/.github/ISSUE_TEMPLATE/api_description.md
@@ -1,0 +1,29 @@
+---
+name: API Requirement
+about: Documentation of API to be developed
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## About this module
+
+Replace this line with a brief description of the module
+
+Here are the route descriptions:
+
+### 1. GET
+`/endpoint/:slug/?query=`
+
+**Queries**
+- `queryField` - query description
+
+**Parameters**
+- `paramField` - param description
+
+**Body**
+- `bodyField` - body param description
+
+**Description** <br/>
+Description of what the route does and additional notes.


### PR DESCRIPTION
hello!

I've added a new issue template relating specifically to backend api documentation / requirements so as to make the requirements clear both for api development and frontend implementation. This can be used by tools like docusaurus directly to generate webpages if needed in the future.